### PR TITLE
fix parsing of non-github repos

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,0 +1,20 @@
+const repos = require('.')
+const packages = require('all-the-package-names')
+const urls = Object.values(repos)
+const github = urls.filter(url => (/github\.com/i).test(url))
+const bitbucket = urls.filter(url => (/bitbucket\.org/i).test(url))
+const gitlab = urls.filter(url => (/gitlab\.com/i).test(url))
+
+function percentage (collection) {
+  return (collection.length / packages.length * 100).toFixed(2) + '%'
+}
+
+console.log(`
+Packages | Count | Percentage of Total Packages
+---- | ----- | ----------
+All | ${packages.length} | 100%
+With repository in package.json | ${urls.length} | ${percentage(urls)}
+On GitHub | ${github.length} |  ${percentage(github)}
+On BitBucket | ${bitbucket.length} |  ${percentage(bitbucket)}
+On GitLab | ${gitlab.length} |  ${percentage(gitlab)}
+`)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "mocha && standard"
   },
   "devDependencies": {
+    "all-the-package-names": "^1.3250.0",
     "chai": "^3.5.0",
     "mocha": "^3.2.0",
     "ora": "^1.1.0",

--- a/readme.md
+++ b/readme.md
@@ -4,9 +4,15 @@ All the repository URLs in the npm registry as an object whose keys are package 
 
 This package weighs in at about 20MB.
 
-- 362820 packages in the npm registry
-- 296959 with a repository in package.json
-- 290741 with a github repository
+## Stats
+
+Packages | Count | Percentage of Total Packages
+---- | ----- | ----------
+All | 490948 | 100%
+With repository in package.json | 377306 | 76.85%
+On GitHub | 366262 |  74.60%
+On BitBucket | 2761 |  0.56%
+On GitLab | 1295 |  0.26%
 
 ## Installation
 
@@ -22,6 +28,8 @@ repos = require('all-the-package-repos')
 repos.express
 // https://github.com/expressjs/express
 ```
+
+See [example.js](example.js) for more usage details.
 
 GitHub URLs are normalized to their `https` form using
 [github-url-to-object](http://ghub.io/github-url-to-object):

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,6 +1,4 @@
-const registry = require('package-stream')({
-  db: 'https://replicate.npmjs.com'
-})
+const registry = require('package-stream')()
 const ora = require('ora')
 const spinner = ora('Loading').start()
 const repos = {}
@@ -10,7 +8,12 @@ registry
   .on('package', function (pkg) {
     spinner.text = String(++totalPackages)
     if (!pkg || !pkg.name || !pkg.repository) return
-    repos[pkg.name] = pkg.repository
+
+    if (pkg.repository.url) {
+      repos[pkg.name] = pkg.repository.url
+    } else {
+      repos[pkg.name] = pkg.repository
+    }
   })
   .on('up-to-date', function () {
     process.stdout.write(JSON.stringify(repos, null, 2))

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ const repos = require('.')
 
 describe('repos', () => {
   it('is an object with lots of values', () => {
-    expect(Object.keys(repos).length).to.be.above(330 * 1000)
+    expect(Object.keys(repos).length).to.be.above(377 * 1000)
   })
 
   it('sets URLs as values', () => {


### PR DESCRIPTION
non-GitHub repo objects were not being properly converted to URL strings. This PR fixes that.

see https://github.com/nice-registry/about/pull/1

cc @vsemozhetbytV