### PR TITLE
hostnames

### DIFF
--- a/hostnames.js
+++ b/hostnames.js
@@ -13,6 +13,6 @@ if (!module.parent) {
   const longestHostname = hostnames.sort((a, b) => b.length - a.length)[0]
 
   counts.forEach(hostname => {
-    console.log(pad(hostname.value, longestHostname.length+3) + String(hostname.count))
+    console.log(pad(hostname.value, longestHostname.length + 3) + String(hostname.count))
   })
 }

--- a/hostnames.js
+++ b/hostnames.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+const URL = require('url')
+const countValues = require('count-array-values')
+const urls = Object.values(require('.'))
+const hostnames = urls.map(url => URL.parse(url).hostname.replace(/^www\./i, ''))
+const counts = countValues(hostnames)
+
+module.exports = counts
+
+if (!module.parent) {
+  const pad = require('pad')
+  const longestHostname = hostnames.sort((a, b) => b.length - a.length)[0]
+
+  counts.forEach(hostname => {
+    console.log(pad(hostname.value, longestHostname.length+3) + String(hostname.count))
+  })
+}

--- a/package.json
+++ b/package.json
@@ -21,5 +21,12 @@
     "ora": "^1.1.0",
     "package-stream": "^3.0.1",
     "standard": "^8.6.0"
+  },
+  "dependencies": {
+    "count-array-values": "^1.2.1",
+    "pad": "^2.0.3"
+  },
+  "bin": {
+    "all-the-package-repo-hostnames": "hostnames.js"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,45 @@ GitHub URLs are normalized to their `https` form using
 - `foo/bar` becomes `https://github.com/foo/bar`
 - [etc...](http://ghub.io/github-url-to-object)
 
+### Repository Hostnames
+
+For the curious, there's a submodule that collects all the hostnames of all the
+repository URLS:
+
+```js
+require('./hostnames').slice(0,10)
+
+[ 
+  { value: 'github.com', count: 452768 },
+  { value: 'bitbucket.org', count: 553 },
+  { value: 'git.oschina.net', count: 219 },
+  { value: 'gitlab.com', count: 116 },
+  { value: 'git.coding.net', count: 114 },
+  { value: 'archive.voodoowarez.com', count: 81 },
+  { value: 'gitee.com', count: 60 },
+  { value: 'gitlab.baidu.com', count: 49 },
+  { value: 'git-wip-us.apache.org', count: 38 },
+  { value: 'gitlab.alibaba-inc.com', count: 36 }
+]
+```
+
+It also has a CLI:
+
+```sh
+all-the-package-repo-hostnames | head -n 10
+
+github.com                                        452768
+bitbucket.org                                     553
+git.oschina.net                                   219
+gitlab.com                                        116
+git.coding.net                                    114
+archive.voodoowarez.com                           81
+gitee.com                                         60
+gitlab.baidu.com                                  49
+git-wip-us.apache.org                             38
+gitlab.alibaba-inc.com                            36
+```
+
 ## Tests
 
 ```sh


### PR DESCRIPTION
This PR adds a module and CLI for listing all hostnames by package count. Here are the top 30.

cc @juliangruber 

Hostname                                          | Packages
------------------------------------------------- | -------
github.com                                        | 452768
bitbucket.org                                     | 553
git.oschina.net                                   | 219
gitlab.com                                        | 116
git.coding.net                                    | 114
archive.voodoowarez.com                           | 81
gitee.com                                         | 60
gitlab.baidu.com                                  | 49
git-wip-us.apache.org                             | 38
gitlab.alibaba-inc.com                            | 36
npmjs.com                                         | 34
gitlab.imginconline.com                           | 32
gitlab.coko.foundation                            | 29
git.cryto.net                                     | 28
github.ibm.com                                    | 27
git.code.oa.com                                   | 24
vehicleregistrationapi.com                        | 22
coding.net                                        | 21
gist.github.com                                   | 21
bitbucket.com                                     | 21
test.git                                          | 21
gitlab.soft-artel.com                             | 20
baidu.com                                         | 19
archive.eldergods.com                             | 18
registry.npmjs.org                                | 18
hub.jazz.net                                      | 17
repo.eecs.berkeley.edu                            | 16
gitlord.com                                       | 16
dev.incardata.com.cn                              | 15
gitlab.58corp.com                                 | 15
```