### PR TITLE
Reduce diff size

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -40,9 +40,18 @@ registry
 
 function done () {
   console.log('\ndone!')
+
+  const sorted = {}
+  const keys = Object.keys(repos).sort()
+
+  for (const key of keys) {
+    sorted[key] = repos[key]
+    delete repos[key]
+  }
+
   fs.writeFileSync(
     path.join(__dirname, '../index.json'),
-    JSON.stringify(repos, null, 2)
+    JSON.stringify(sorted, null, 2)
   )
   process.exit()
 }


### PR DESCRIPTION
This will make the build script to alphabetical list the packages
on the `index.json`, which will reduce the diff size of the daily update.

This approach provides a nice side-effect that every day the diff
will only contain those packages that were added or removed since
the last update.