### PR TITLE
Use GitHub Actions to create npm releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  schedule:
+    - cron: "0 */8 * * *"
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: npm ci
+      run: npm ci
+    - name: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        git checkout "${GITHUB_HEAD_REF}"
+        git config --global user.name "github-actions"
+        git config --global user.email "github-actions@users.noreply.github.com"
+        git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+        npm run build
+        npm run stats
+        npm test
+        [[ `git status --porcelain` ]] || exit
+        git add .
+        git commit -am "update all-the-package-repos"
+        npm version minor -m "bump minor to %s"
+        git push origin master --follow-tags
+        npm publish

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+.npmrc
+node_modules

--- a/test.js
+++ b/test.js
@@ -18,6 +18,7 @@ describe('repos', () => {
   })
 
   it('is always a URL', () => {
+    this.timeout(10 * 1000)
     const urls = Object.values(repos)
     urls.forEach(url => {
       expect(isUrl(url), `${url}`).to.eq(true)

--- a/test.js
+++ b/test.js
@@ -17,7 +17,7 @@ describe('repos', () => {
     expect(repos.express).to.equal('https://github.com/expressjs/express')
   })
 
-  it('is always a URL', () => {
+  it('is always a URL', function () {
     this.timeout(10 * 1000)
     const urls = Object.values(repos)
     urls.forEach(url => {


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow to publish new releases on a schedule. Probably won't work the first time, but it's a start. 🤞 

cc @eridal 