### PR TITLE
Github Action: reduce log noise

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -13,9 +13,11 @@ registry
     spinner.text = String(++totalPackages)
     if (!pkg || !pkg.name || !pkg.repository) return
 
+    /* uncomment for debug
     if (totalPackages > 500 * 1000) {
       console.log(pkg.name)
     }
+    // */
 
     const repo = (pkg.repository.url) ? pkg.repository.url : pkg.repository
     let parsed


### PR DESCRIPTION
@zeke The build is still failing and due to this statement the logs are quite cluttered.

Seems like that was added for debug purposes, please let me know if that assumption is not correct

