### PR TITLE
Update repos and npm version in a single commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,9 @@ jobs:
         npm run stats
         npm test
         [[ `git status --porcelain` ]] || exit
+
         git add .
-        git commit -am "update all-the-package-repos"
-        npm version minor -m "bump minor to %s"
+        npm version minor -f -m "update all-the-package-repos to %s"
+
         git push origin master --follow-tags
         npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
         [[ `git status --porcelain` ]] || exit
 
         git add .
+        # bump the version, commit, and create a tag
         npm version minor -f -m "update all-the-package-repos to %s"
 
         git push origin master --follow-tags


### PR DESCRIPTION
This is just an idea.

Instead of committing twice every time (update + version) this change will make the script perform a single update.

I can see the benefits of both approaches and given that this is an automated process seems cleaner to be a single atomic change, at least to me.