### PR TITLE
[draft] Incremental updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 .npmrc
+.cache/
 node_modules

--- a/data/metadata.json
+++ b/data/metadata.json
@@ -1,0 +1,26 @@
+{
+  "packages": 0,
+  "last": 0,
+  "latest": 0,
+  "runs": {
+    "total": 0,
+    "status": {
+    }
+  },
+  "repos": {
+    "github": 0,
+    "gitlab": 0,
+    "bitbucket": 0,
+    "others": 0
+  },
+  "stats": {
+    "changes": 0,
+    "inserts": 0,
+    "updates": 0,
+    "deletes": 0,
+    "invalid": 0,
+    "ignored": 0
+  },
+  "batch": {
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,36 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
+      "integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ==",
+      "dev": true
+    },
+    "@types/request": {
+      "version": "2.48.4",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.4.tgz",
+      "integrity": "sha512-W1t1MTKYR8PxICH+A4HgEIPuAC3sbljoEVfyZbeFJJDbr30guDspJri2XOaM2E+Un7ZjrihaDi7cf6fPa2tbgw==",
+      "dev": true,
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      }
+    },
+    "@types/tough-cookie": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.6.tgz",
+      "integrity": "sha512-wHNBMnkoEBiRAd3s8KTKwIuO9biFtTf0LehITzBhSco+HQI0xkXZbLOD55SW3Aqw3oUkHstkm5SPv58yaAdFPQ==",
+      "dev": true
+    },
     "acorn": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
@@ -97,10 +127,43 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
     "assertion-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
       "dev": true
     },
     "babel-code-frame": {
@@ -126,6 +189,24 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "bitbucket-url-to-object": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/bitbucket-url-to-object/-/bitbucket-url-to-object-0.3.0.tgz",
+      "integrity": "sha1-1olAFAgWw+AMtKMfvPjmQOD0rhc=",
+      "dev": true,
+      "requires": {
+        "is-url": "^1.1.0"
+      }
+    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -135,6 +216,12 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "browser-request": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
+      "integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc=",
+      "dev": true
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -161,6 +248,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
       "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "chai": {
@@ -247,6 +340,34 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
       "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
     },
+    "cloudant-follow": {
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.18.2.tgz",
+      "integrity": "sha512-qu/AmKxDqJds+UmT77+0NbM7Yab2K3w0qSeJRzsq5dRWJTEJdWeb+XpG4OpKuTE9RKOa/Awn2gR3TTnvNr3TeA==",
+      "dev": true,
+      "requires": {
+        "browser-request": "~0.3.0",
+        "debug": "^4.0.1",
+        "request": "^2.88.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -258,6 +379,15 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "commander": {
       "version": "2.9.0",
@@ -346,6 +476,15 @@
         "es5-ext": "^0.10.9"
       }
     },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
@@ -421,6 +560,12 @@
         "rimraf": "^2.2.8"
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
     "diff": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
@@ -449,6 +594,22 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "errs": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/errs/-/errs-0.3.2.tgz",
+      "integrity": "sha1-eYCZstvTfKK8dJ5TinwTB9C1BJk=",
       "dev": true
     },
     "es5-ext": {
@@ -669,6 +830,30 @@
       "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -713,6 +898,23 @@
         "write": "^0.2.1"
       }
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -745,6 +947,15 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "github-url-to-object": {
       "version": "4.0.2",
@@ -826,6 +1037,36 @@
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+          "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        }
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -862,6 +1103,17 @@
       "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
       "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
       "dev": true
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
     },
     "ignore": {
       "version": "3.3.7",
@@ -1023,6 +1275,12 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
     "is-url": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
@@ -1033,6 +1291,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "js-tokens": {
@@ -1051,6 +1315,24 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
@@ -1059,6 +1341,12 @@
       "requires": {
         "jsonify": "~0.0.0"
       }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json3": {
       "version": "3.3.2",
@@ -1077,6 +1365,18 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
     },
     "jsx-ast-utils": {
       "version": "1.4.1",
@@ -1183,6 +1483,21 @@
       "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
       "dev": true
     },
+    "mime-db": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.43.0"
+      }
+    },
     "mimic-fn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
@@ -1245,6 +1560,36 @@
       "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
     },
+    "nano": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/nano/-/nano-8.2.2.tgz",
+      "integrity": "sha512-1/rAvpd1J0Os0SazgutWQBx2buAq3KwJpmdIylPDqOwy73iQeAhTSCq3uzbGzvcNNW16Vv/BLXkk+DYcdcH+aw==",
+      "dev": true,
+      "requires": {
+        "@types/request": "^2.48.4",
+        "cloudant-follow": "^0.18.2",
+        "debug": "^4.1.1",
+        "errs": "^0.3.2",
+        "request": "^2.88.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -1288,6 +1633,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
     "object-assign": {
@@ -1389,6 +1740,12 @@
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -1451,6 +1808,24 @@
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
+    "psl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
+    },
     "readable-stream": {
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -1481,6 +1856,53 @@
       "dev": true,
       "requires": {
         "resolve": "^1.1.6"
+      }
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "dev": true
+        }
       }
     },
     "require-uncached": {
@@ -1560,6 +1982,12 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
@@ -1594,6 +2022,23 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
     },
     "standard": {
       "version": "8.6.0",
@@ -1744,10 +2189,35 @@
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
     },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
     "tryit": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "type-check": {
@@ -1783,6 +2253,15 @@
       "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
       "dev": true
     },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -1806,6 +2285,23 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
     },
     "wcwidth": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
   },
   "devDependencies": {
     "all-the-package-names": "^1.3395.0",
+    "bitbucket-url-to-object": "^0.3.0",
     "chai": "^3.5.0",
     "github-url-to-object": "^4.0.2",
     "is-url": "^1.2.2",
     "mocha": "^3.2.0",
+    "nano": "^8.2.2",
     "ora": "^1.1.0",
     "package-stream": "^3.0.1",
     "standard": "^8.6.0"

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -1,0 +1,642 @@
+const fs = require('fs')
+const url = require('url')
+const path = require('path')
+const nano = require('nano')
+
+const isUrl = require('is-url')
+const to = {
+  github: require('github-url-to-object'),
+  bitbucket: require('bitbucket-url-to-object'),
+}
+
+/**
+ * Where the support files are stored
+ */
+const files = {
+  packages: path.join(__dirname, '../data/packages.json'),
+  metadata: path.join(__dirname, '../data/metadata.json'),
+}
+
+const packages = fs.existsSync(files.packages) ? require(files.packages) : {}
+const metadata = fs.existsSync(files.metadata) ? require(files.metadata) : {}
+
+/**
+ * State info about the changes being processed
+ */
+const batch = {
+  // How many changes to apply during the process (or `<= 0` to disable)
+  limit: 0,
+}
+
+/**
+ * Statistics gathered during the process
+ */
+const stats = {
+  // revisions processed
+  changes: 0,
+  // operations executed
+  inserts: 0,
+  updates: 0,
+  deletes: 0,
+  // wrong repo urls
+  invalid: 0,
+  // unable to process
+  ignored: 0
+}
+
+/**
+ * Stats about the repos
+ */
+const repos = {
+  github: 0,
+  gitlab: 0,
+  bitbucket: 0,
+  others: 0,
+}
+
+/**
+ * Cache changes to disk, for faster historical rebuild
+ */
+const caches = {
+
+  // Directory to temporarily store changes, or `null` to disable
+  path: process.env.ENABLE_CACHE
+    ? path.join(__dirname, '../.cache')
+    : null
+  ,
+
+  // How many entries per file
+  size: 10000,
+}
+
+/**
+ * Display update progress animation
+ */
+const progress = {
+  // minimum time to shown something (in millis)
+  delay: 1000 * 60 * 15,
+  // space between changes, range (0, 100)
+  steps: 5.0,
+  // min percent change
+  scale: 0.01,
+}
+
+const setupBatch = async (db) => {
+
+  const relax = await db.relax()
+
+  // 1. was the previous ran an error?
+
+  if (metadata.error) {
+
+    const previousLimit = metadata.batch
+                       && metadata.batch.limit
+                       || batch.limit
+
+    if (previousLimit > 1) {
+      // attempt only the problematic change
+      batch.limit = 1
+    }
+    else {
+      // whatever, skip the bad one
+      metadata.ignored = metadata.ignored || []
+      metadata.ignored.push(metadata.last)
+      metadata.last += 1
+      stats.ignored += 1
+    }
+  }
+
+  // 2. setup batch limits
+
+  batch.latest = relax.update_seq
+  batch.index =
+  batch.since = metadata.last || 0
+  batch.until = Math.min(
+    batch.limit > 0
+      ? batch.since + batch.limit
+      : Infinity
+    ,
+    batch.latest
+  )
+
+  // 3. prepare batch stats collection
+
+  batch.started = new Date()
+  batch.finished = false
+  batch.took_ms = -1
+  batch.found = 0
+
+  if (!batch.limit || batch.limit <= 0 || !Number.isFinite(batch.limit)) {
+    batch.limit = batch.until - batch.since
+  }
+
+  delete metadata.error
+}
+
+/**
+ * @param {object} object
+ * @param {string|integer} spaces [optional] default 2 spaces
+ *
+ * @return {string}
+ */
+const toJson = (object, spaces) => {
+  return JSON.stringify(object, null, spaces || 2)
+}
+
+/**
+ * @param {object} object
+ * @return {object}
+ */
+const sort = (object) => {
+
+  const sorted = {}
+  const keys = Object.keys(object).sort()
+
+  for (const key of keys) {
+    sorted[key] = object[key]
+    delete object[key]
+  }
+
+  return sorted
+}
+
+const cache = (change) => {
+
+  if (!caches.path) {
+    return // cache is disabled
+  }
+
+  const isDelete = change.deleted
+  const isGitUrl = change.doc
+                && change.doc.repository
+
+  if (!(isDelete || isGitUrl)) {
+    return // not worth keeping
+  }
+
+  const entry = {
+    seq: change.seq,
+    id: change.id,
+  }
+
+  if (isDelete) {
+    entry.deleted = true
+  } else {
+    entry.doc = {
+      repository: change.doc.repository
+    }
+  }
+
+  caches.buffer = caches.buffer || []
+  caches.buffer.push(entry)
+
+  if (caches.buffer.length >= caches.size) {
+    writeCache()
+  }
+}
+
+/**
+ *
+ */
+const apply = (change) => {
+
+  batch.index = change.seq
+  batch.found += 1
+
+  stats.changes += 1
+
+  const name = change.id
+  const curr = packages[name]
+
+  if (change.deleted) {
+
+    if (typeof curr === 'string') {
+      updateRepoStats(curr, -1)
+    }
+
+    stats.deletes += 1
+    return delete packages[name]
+  }
+
+  const url = extractUrl(change)
+
+  if (!url) {
+    stats.invalid += 1
+    return
+  }
+
+  if (typeof curr === 'string') {
+    updateRepoStats(curr, -1)
+    stats.updates += 1
+  }
+  else {
+    stats.inserts += 1
+  }
+
+  packages[name] = url
+  updateRepoStats(url, +1)
+}
+
+/**
+ * @return {string} - repo url
+ */
+const extractUrl = (change) => {
+
+  const repo = change.doc
+            && change.doc.repository
+
+  return repo && parseUrl(repo)
+}
+
+const urlToObject = (parse) => {
+  return (url) => {
+    const found = parse(url)
+    return found && found.https_url
+  }
+}
+
+const plainUrl = (url) => {
+  if (isUrl(url) && url.startsWith('http')) {
+    return url
+  }
+}
+
+const URL_PARSERS = [
+  urlToObject(to.github),
+  urlToObject(to.bitbucket),
+  plainUrl,
+]
+
+const parseUrl = (repo) => {
+
+  const url = typeof repo === 'string'
+    ? repo
+    : repo.url
+
+  if (typeof url !== 'string') {
+    return
+  }
+
+  for (const parse of URL_PARSERS) {
+    try {
+      let result = parse(url)
+      if (result) return result
+    }
+    catch (err) {
+      continue
+    }
+  }
+}
+
+const TYPES = [
+  {
+    name: 'github',
+    rule: /^github\./,
+  },
+  {
+    name: 'gitlab',
+    rule: /^gitlab\./,
+  },
+  {
+    name: 'bitbucket',
+    rule: /^bitbucket\./,
+  },
+]
+
+const extractType = (url) => {
+
+  const domain = extractDomain(url)
+
+  if (domain) {
+    for (const type of TYPES) {
+      if (type.rule.test(domain)) {
+        return type.name
+      }
+    }
+  }
+
+  return 'others'
+}
+
+const extractDomain = (repoUrl) => {
+
+  try {
+    const { hostname } = url.parse(repoUrl)
+    return hostname.replace(/^www\./i, '')
+  }
+  catch (err) {
+    // empty
+  }
+}
+
+const updateRepoStats = (url, delta) => {
+  const type = extractType(url)
+  repos[type] = (repos[type] || 0) + Math.sign(delta)
+}
+
+/**
+ * @return {Error} - or `null` on normal exit
+ */
+const updateStats = () => {
+
+  batch.finished = new Date()
+  batch.took_ms = batch.finished - batch.started
+
+  const status = buildStatus()
+
+  metadata.packages = Object.keys(packages).length
+  metadata.last = batch.index
+               || batch.since
+
+  metadata.latest = batch.latest
+
+  metadata.runs = metadata.runs || {}
+  metadata.runs.total = (metadata.runs.total || 0) + 1
+  metadata.runs.status = metadata.runs.status || {}
+  metadata.runs.status[status] = (metadata.runs.status[status] || 0) + 1
+
+  metadata.repos = metadata.repos || {}
+  metadata.stats = metadata.stats || {}
+  metadata.batch = batch
+
+  for (const key of Object.keys(stats)) {
+    metadata.stats[key] = (metadata.stats[key] || 0) + stats[key]
+  }
+
+  for (const key of Object.keys(repos)) {
+    metadata.repos[key] = (metadata.repos[key] || 0) + repos[key]
+  }
+
+  batch.status = status
+
+  const err = batch.error
+
+  if (err) {
+    metadata.error = true
+  }
+
+  delete batch.latest
+  delete batch.error
+
+  if (err instanceof Error) {
+    return err
+  }
+}
+
+const buildStatus = () => {
+
+  if (batch.status) return batch.status
+
+  if (batch.found === 0) {
+    metadata.error = true
+    return 'empty'
+  }
+
+  delete metadata.error
+
+  return 'ok'
+}
+
+const printProgress = (() => {
+
+  // keeps track of the percent indicator
+  let next = -1
+  let time = 0
+
+  // used for scale
+  const mul = 1 / progress.scale * 100
+  const div = mul / 100
+
+  return (force) => {
+
+    if (next < 0) {
+      next = 0
+      time = Date.now()
+      console.log('applying changes...')
+      return
+    }
+
+    const complete = 1 - (batch.until - batch.index) / batch.limit
+    const percent = Math.round(complete * mul) / div
+    const elapsed = Date.now() - time
+
+    const hasAdvanced = percent >= next
+    const hasTimedout = elapsed >= progress.delay
+
+    if (force || hasAdvanced || hasTimedout) {
+      next = percent + progress.steps
+      time = Date.now()
+      console.log('- %d%%', percent)
+    }
+  }
+})()
+
+const writeChanges = (deferred) => {
+  console.log('writting changes...')
+
+  const err = updateStats()
+
+  fs.writeFileSync(files.metadata, toJson(metadata))
+
+  if (batch.found > 0) {
+    fs.writeFileSync(files.packages, toJson(sort(packages)))
+  }
+
+  writeCache()
+
+  err ? deferred.reject(err)
+      : deferred.resolve()
+}
+
+const writeCache = () => {
+
+  if (!caches.path) {
+    return // cache is disabled
+  }
+
+  if (!caches.buffer || caches.buffer.length === 0) {
+    return  // empty cache
+  }
+
+  let next = caches.index || -1
+  let file
+
+  do {
+    next += 1
+    file = path.join(caches.path, `${next}.json`)
+  } while (fs.existsSync(file));
+
+  // using plain JSON.stringify to reduce file size
+  fs.writeFileSync(file, toJson(caches.buffer, '\t'))
+
+  caches.buffer.length = 0
+  caches.index = next
+}
+
+const processCached = () => {
+
+  if (!caches.path) {
+    return // cache is disabled
+  }
+
+  console.log('reading cache...')
+
+  const changeList = []
+
+  let files = 0
+  let changes = 0
+
+  for (const file of fs.readdirSync(caches.path)) {
+
+    if (!/^\d+\.json$/.test(file)) {
+      continue
+    }
+
+    files += 1
+
+    const entries = require(
+      path.join(caches.path, file)
+    )
+
+    for (const change of entries) {
+      changes += 1
+      if (batch.index < change.seq && change.seq <= batch.until) {
+        changeList.push(change)
+      }
+    }
+  }
+
+  console.log(' -> found %d files', files)
+  console.log(' -> found %d changes', changes)
+
+  changeList.sort((a, b) => a.seq - b.seq)
+
+  const added = new Map()
+
+  for (const change of changeList) {
+
+    if (added.has(change.seq)) {
+      continue // ups, repeated cache entry
+    }
+
+    apply(change)
+
+    batch.since = batch.index
+    added.set(change.seq)
+  }
+
+  console.log(' -> added %d entries', batch.found)
+}
+
+/**
+ * Main
+ */
+!(async () => {
+
+  const db = nano('https://replicate.npmjs.com')
+
+  await setupBatch(db)
+  await processCached()
+
+  console.log('batch:')
+  console.log({
+    limit: batch.limit,
+    since: batch.since,
+    index: batch.index,
+    until: batch.until,
+    started: batch.started,
+  })
+
+  const request = {
+    since: batch.since,
+    include_docs: true,
+    inactivity_ms: 1000 * 60 * 2, // 2 minutes
+    heartbeat: 1000 * 60 * 10, // 10 minutes
+  }
+
+  if (batch.limit > 0 && Number.isFinite(batch.limit)) {
+    request.limit = batch.limit
+  }
+
+  const feed = await db
+    .use('')
+    .follow(request)
+
+  feed.on('change', (change) => {
+
+    cache(change)
+    apply(change)
+
+    printProgress()
+
+    if (batch.index >= batch.until) {
+      console.log('finish!')
+      feed.stop()
+    }
+  })
+
+  feed.on('catchup', () => {
+    console.log('up to date!')
+    feed.stop()
+  })
+
+  feed.on('restart', () => {
+    console.log('restart!')
+    batch.status = 'restart'
+    batch.error = true
+    feed.stop()
+  })
+
+  feed.on('timeout', () => {
+    console.log('timeout!')
+    batch.status = 'timeout'
+    batch.error = true
+    feed.stop()
+  })
+
+  feed.on('error', (err) => {
+    console.log('error!')
+    batch.status = 'error'
+    batch.error = err
+    feed.stop()
+  })
+
+  process.once('SIGTERM', () => {
+    console.log('cancelled!')
+    batch.status = 'cancelled'
+    feed.stop()
+  })
+
+  process.once('SIGINT', () => {
+    console.log('cancelled!')
+    batch.status = 'cancelled'
+    feed.stop()
+  })
+
+  process.on('SIGUSR1', () => {
+    const force = true
+    printProgress(force)
+  })
+
+  const deferred = {}
+
+  feed.once('stop', () => {
+    writeChanges(deferred)
+  })
+
+  return new Promise((resolve, reject) => {
+    deferred.resolve = resolve
+    deferred.reject = reject
+    feed.start()
+  })
+
+})().then(
+  () => {
+    console.log(metadata)
+    process.exit(0)
+  },
+  (err) => {
+    console.error(err)
+    process.exit(1)
+  }
+)


### PR DESCRIPTION
I'm adding the draft for the **incremental updates** proposal.

Although it is still not complete, the code wont change much. What is currently missing is the fact that the end result is duplicated, so we are able to compare both datasets: `index.json` for the current process and `data/packages.json` which this script outputs. 

Also I've added [bitbucket-url-to-object](https://www.npmjs.com/package/bitbucket-url-to-object) but I'm still not sure if it is a good idea to be included as part of this change as doing so will amplify the divergence between the `index.json` and `data/packages.json`.

Before merging this we should unify those two datasets into a single one.

---

On a separate subject, the metadata (file `data/metadata.json`) is where the process keeps track of the previous executions, which this PR only include empty defaults, aka all zeros. I'm currently executing this process from my computer, which is a really expensive operation from my country's internet (and also why we needed the optional cache mechanism)

At this point it is not clear what is the best course of action, if either setup the process to execute from scratch, or manually configure the output of my manual executions. What we do know is that the process gets interrupted by really large documents (files of 60Mb+), which could prevent running safely this from the cloud: the end result of an interrupted execution will be to publish a new version with partial historical data.

This could be quickly validated by anyone with access to a faster internet: just execute the process from scratch and let's see if it is able to process the entire history in one go. Please remember doing so will take at least 3 hours.

---

Just for reference here are the metadata of my manual testing:

```js
{ packages: 754278,
  last: 5008165,
  latest: 5517514,
  runs: {
    total: 9
    status: { cancelled: 7, restart: 1, ok: 1 } },
  repos:
   { github: 743367,
     gitlab: 2433,
     bitbucket: 942,
     others: 7536 },
  stats:
   { changes: 824373,
     inserts: 754278,
     updates: 0,
     deletes: 36043,
     invalid: 34052,
     ignored: 0 },
  batch:
   { limit: 509351,
     since: 5008163,
     index: 5008165,
     until: 5517514,
     started: '2020-03-13T02:39:51.134Z',
     finished: '2020-03-13T02:41:38.945Z',
     took_ms: 107811,
     found: 2,
     status: 'cancelled' } }
```
cc @zeke's