### PR TITLE
Allow batch limit from cli

### DIFF
--- a/scripts/update.js
+++ b/scripts/update.js
@@ -25,7 +25,7 @@ const metadata = fs.existsSync(files.metadata) ? require(files.metadata) : {}
  */
 const batch = {
   // How many changes to apply during the process (or `<= 0` to disable)
-  limit: 0
+  limit: process.env.BATCH_LIMIT * 1 || 0
 }
 
 /**


### PR DESCRIPTION
This change allows developers to execute with limit. This change will not change nothing on GitHub executions