### PR TITLE
Allow null as repository url

### DIFF
--- a/lib/stats-tpl.js
+++ b/lib/stats-tpl.js
@@ -13,16 +13,26 @@ module.exports = {
     const total = metadata.packages
     const repos = metadata.repos
 
+    const areNull = repos.unsets || 0
+    const notNull = total - areNull
+
     const perc = (val) => (val * 100 / total).toFixed(2)
+
     return dedent`
       <!-- stats -->
       Packages | Count | Percentage
-      -------- | ----- | ----------
-      With repository in package.json | ${total} | 100%
+      :------- | -----:| ----------:
+      With repository | ${notNull} | ${perc(notNull)}%
+      Null repository | ${areNull} | ${perc(areNull)}%
+      **Total** | ${total} | ${perc(total)}%
+
+      Providers | Count | Percentage
+      :-------- | -----:| ----------:
       GitHub | ${repos.github} | ${perc(repos.github)}%
       GitLab | ${repos.gitlab} | ${perc(repos.gitlab)}%
       Bitbucket | ${repos.bitbucket} | ${perc(repos.bitbucket)}%
       Others | ${repos.others} | ${perc(repos.others)}%
+      **Total** | ${notNull} | ${perc(notNull)}%
       <!-- /stats -->
       `
   }

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -1,0 +1,64 @@
+const describe = require('mocha').describe
+const it = require('mocha').it
+const expect = require('chai').expect
+
+const packages = require('../data/packages.json')
+const metadata = require('../data/metadata.json')
+
+const sum = (a, b) => a + b
+
+describe('metadata', () => {
+  describe('repos', () => {
+    it('should match repos', () => {
+      const real = Object
+          .keys(packages)
+          .length
+
+      const repos = Object
+          .values(metadata.repos)
+          .reduce(sum, 0)
+
+      expect(repos)
+        .to.be.equals(real)
+    })
+
+    it('should match unsets', () => {
+      const real = Object
+          .values(packages)
+          .filter(url => url === null)
+          .length
+
+      expect(metadata.repos.unsets || 0)
+        .to.be.equals(real)
+    })
+
+    it('should match urls', () => {
+      const real = Object
+          .values(packages)
+          .filter(Boolean)
+          .length
+
+      const repos = Object
+        .values(metadata.repos)
+        .reduce(sum, 0)
+
+      const others = repos - (metadata.repos.unsets || 0)
+
+      expect(others)
+        .to.be.equals(real)
+    })
+  })
+
+  describe('stats', () => {
+    it('should correctly count changes', () => {
+      const changes = metadata.stats.inserts +
+                      metadata.stats.updates +
+                      metadata.stats.deletes +
+                      metadata.stats.invalid +
+                      metadata.stats.ignored
+
+      expect(metadata.stats.changes)
+        .to.be.equals(changes)
+    })
+  })
+})

--- a/test/repos.js
+++ b/test/repos.js
@@ -19,10 +19,9 @@ describe('repos', () => {
 
   it('is always a URL', function () {
     this.timeout(10 * 1000)
-    const urls = Object.values(repos)
-    urls.forEach(url => {
-      expect(isUrl(url), `${url}`).to.eq(true)
-    })
+    for (const url of Object.values(repos)) {
+      expect(url === null || isUrl(url), url).to.eq(true)
+    }
   })
 
   it('includes scoped package names', () => {

--- a/test/stats.js
+++ b/test/stats.js
@@ -14,22 +14,31 @@ describe('stats', () => {
 
   it('should build the correct table', () => {
     const metadata = {
-      packages: 12,
       repos: {
-        github: 3,
-        gitlab: 4,
-        bitbucket: 6,
-        others: 9
+        github: 1,
+        gitlab: 2,
+        bitbucket: 3,
+        unsets: 4,
+        others: 5
       }
     }
+
+    metadata.packages = Object
+      .values(metadata.repos)
+      .reduce((a, b) => a + b, 0)
+
     const table = tpl.build(metadata)
+
     expect(table)
       .to.be.a('string')
       .to.match(tpl.regex)
-      .to.match(/With repository in package.json \| 12 \| 100%/)
-      .to.match(/GitHub \| 3 \| 25\.00%/)
-      .to.match(/GitLab \| 4 \| 33\.33%/)
-      .to.match(/Bitbucket \| 6 \| 50\.00%/)
-      .to.match(/Others \| 9 \| 75\.00%/)
+      .to.match(/With repository \| 11 \| 73.33%/)
+      .to.match(/Null repository \| 4 \| 26.67%/)
+      .to.match(/\*\*Total\*\* \| 15 \| 100.00%/)
+      .to.match(/GitHub \| 1 \| 6.67%/)
+      .to.match(/GitLab \| 2 \| 13.33%/)
+      .to.match(/Bitbucket \| 3 \| 20.00%/)
+      .to.match(/Others \| 5 \| 33.33%/)
+      .to.match(/\*\*Total\*\* \| 11 \| 73.33%/)
   })
 })


### PR DESCRIPTION
I know others are working on this same thing, so what happened was that yesterday I started analyzing this change as part of the convo in #36. The test split was a great idea, it allowed me to quickly write the tests to validate the metadata, which lead to a few tweaks here and there and now this is working.

I'm proposing to split the readme table in two, so that the first one will show how many repos with url vs repos with null, while the second table shows the git hosting used. Currently it will look like this: (numbers are real)

Packages | Count | Percentage
:------- | -----:| ----------:
With repository | 1104782 | 99.99%
Null repository | 105 | 0.01%
**Total** | 1104887 | 100.00%

Providers | Count | Percentage
:-------- | -----:| ----------:
GitHub | 1085204 | 98.22%
GitLab | 3951 | 0.36%
Bitbucket | 1215 | 0.11%
Others | 14412 | 1.30%
**Total** | 1104782 | 99.99%

This change can be safely merged and from there new `null` repos will be added as expected, but we will need to apply a full history reprocess to incorporate what the past code ignored.