### PR TITLE
Patch URL handling in the DB follower

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "all-the-package-names": "^1.3395.0",
         "bitbucket-url-to-object": "^0.3.0",
         "chai": "^4.3.6",
+        "cloudant-follow": "^0.18.2",
         "dedent": "^0.7.0",
         "github-url-to-object": "^4.0.2",
         "is-url": "^1.2.2",
@@ -623,6 +624,7 @@
       "integrity": "sha512-qu/AmKxDqJds+UmT77+0NbM7Yab2K3w0qSeJRzsq5dRWJTEJdWeb+XpG4OpKuTE9RKOa/Awn2gR3TTnvNr3TeA==",
       "deprecated": "This package is no longer maintained.",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "browser-request": "~0.3.0",
         "debug": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "all-the-package-names": "^1.3395.0",
     "bitbucket-url-to-object": "^0.3.0",
     "chai": "^4.3.6",
+    "cloudant-follow": "^0.18.2",
     "dedent": "^0.7.0",
     "github-url-to-object": "^4.0.2",
     "is-url": "^1.2.2",


### PR DESCRIPTION
The follower package, internally used by `nano`, expects the URL to NOT end with a slash, but `nano` adds it, and the resulting URLs then look like `https://replicate.npmjs.com//_...`

This used to work fine, but last month, something changed on the npm side, and now such URLs return a 400, breaking our updates.

The package is deprecated and even removed in more recent `nano` versions. To avoid a larger refactoring on our side, I chose to simply wrap it and remove the extra slash.